### PR TITLE
Initialisation du projet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Scratchpad (tests, brouillons)
+works/scratchpad/

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,0 +1,23 @@
+Licence MIT
+
+Copyright (c) 2025 PERARD (MonLucCo / PerLucCo)
+
+La permission est accordée, gratuitement, à toute personne obtenant une copie 
+de ce logiciel et des fichiers de documentation associés (le « Logiciel »), 
+d'utiliser le Logiciel sans restriction, y compris sans limitation les droits 
+d'utiliser, copier, modifier, fusionner, publier, distribuer, sous-licencier 
+et/ou vendre des copies du Logiciel, et de permettre aux personnes à qui le 
+Logiciel est fourni de le faire, sous réserve des conditions suivantes :
+La notice de copyright ci-dessus et cette notice de permission doivent être 
+incluses dans toutes les copies ou parties substantielles du Logiciel.
+LE LOGICIEL EST FOURNI « TEL QUEL », SANS GARANTIE D'AUCUNE SORTE, EXPRESSE OU 
+IMPLICITE, Y COMPRIS MAIS SANS S'Y LIMITER AUX GARANTIES DE QUALITÉ MARCHANDE, 
+D'ADÉQUATION À UN USAGE PARTICULIER ET DE NON-VIOLATION. EN AUCUN CAS LES 
+AUTEURS OU LES DÉTENTEURS DU COPYRIGHT NE POURRONT ÊTRE TENUS RESPONSABLES DE 
+TOUTE RÉCLAMATION, DOMMAGE OU AUTRE RESPONSABILITÉ, QUE CE SOIT DANS UNE 
+ACTION CONTRACTUELLE, DÉLICTUELLE OU AUTRE, DÉCOULANT DE, HORS DE OU EN 
+RELATION AVEC LE LOGICIEL OU L'UTILISATION OU D'AUTRES INTERACTIONS AVEC LE 
+LOGICIEL.
+
+---
+🔗 Pour la version originale en anglais, voir [`docs/LICENSE_EN.txt`](docs/LICENSE_EN.txt)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,136 @@
-# PLC_Babacar-Tour_web-site
+# 🌍 Babacar Tour – Dépôt principal du projet
+
+Ce dépôt regroupe **l’ensemble du projet**, organisé par sous-projets (frontend, backend...), ressources techniques et livraisons successives qui permettent la mise en oeuvre et l'exploitation opérationnelle du site web destiné à valoriser l'activité de **Babacar**.
+
+---
+
+- [🌍 Babacar Tour – Dépôt principal du projet](#-babacar-tour--dépôt-principal-du-projet)
+  - [🧭 Présentation et objectifs du projet Babacar Tour](#-présentation-et-objectifs-du-projet-babacar-tour)
+  - [🧱 Arborescence du dépôt](#-arborescence-du-dépôt)
+  - [📦 Suivi des versions et livraisons](#-suivi-des-versions-et-livraisons)
+  - [🧰 Technologies utilisées](#-technologies-utilisées)
+  - [🎨 Crédit du template](#-crédit-du-template)
+  - [🗂️ Gestion du dépôt](#️-gestion-du-dépôt)
+  - [👨‍💻 Responsable projet](#-responsable-projet)
+  - [🤝 Participer au projet](#-participer-au-projet)
+  - [📄 Licence](#-licence)
+  - [📌 Liens utiles](#-liens-utiles)
+
+---
+
+## 🧭 Présentation et objectifs du projet Babacar Tour
+
+**Babacar Tour** est un site vitrine touristique conçu pour accompagner le développement de l’activité de **Babacar**, chauffeur-guide indépendant au Sénégal. Il propose des excursions personnalisées, des circuits culturels et des transferts pour les voyageurs en quête d’authenticité.
+
+L’objectif du projet est de concevoir et mettre en service une plateforme web qui réponde aux besoins suivants :
+
+- Renforcer la **visibilité en ligne** de Babacar en complément de sa présence sur les réseaux sociaux
+- Mettre en valeur ses **prestations** : excursions, photos, témoignages, itinéraires
+- Faciliter la **prise de contact** : formulaire, WhatsApp, interaction directe
+- Offrir une **interface mobile-first** accessible aux clients européens et sénégalais
+- Déployer une **architecture technique évolutive**, capable d’intégrer des fonctionnalités futures (commentaires, back-office, multilingue)
+- Livrer la solution sur l’hébergeur **Alwaysdata**, selon une démarche **agile orientée release**.
+
+---
+
+## 🧱 Arborescence du dépôt
+
+```bash
+babacar-tour/
+├── docs/         # Cahiers des charges, schémas, ressources visuelles
+├── works/        # Sous-projets techniques (frontend, backend, etc.)
+│   ├── frontend/         # Application Angular du site vitrine
+│   ├── backend/          # (optionnel) API REST pour admin, commentaires, etc.
+│   ├── assets/           # Logos, icônes, bannières, images partagées
+│   └── scratchpad/       # 📂 Zone hors-Git pour tests, brouillons, explorations
+├── releases/     # Livraisons successives du projet (v0.1 → v2.0)
+├── .gitignore
+├── LICENCE.txt
+├── README.md
+```
+
+| Dossier | Lien | Description |
+|--------|------|-------------|
+| `/docs/` | [📁 docs](docs/) | Cahiers des charges, schémas, ressources visuelles |
+| `/works/` | [📁 works](works/) | Sous-projets techniques : frontend, backend, assets |
+| `/releases/` | [📁 releases](releases/) | Livraisons successives du projet |
+| `/LICENSE.txt` | [📄 LICENCE](LICENSE.txt) | Texte juridique en français (MIT) |
+| `/README.md` | – | Présentation principale du projet |
+
+> ✅ Le dossier `scratchpad/` dans `works/` est exclu du suivi Git (`.gitignore`) : il permet d’expérimenter du code, des styles ou des outils sans les versionner.
+
+---
+
+## 📦 Suivi des versions et livraisons
+
+Les livraisons sont planifiées en milestones agiles, avec tracking des issues et organisation par release :
+
+| Version | Objectif | Dossier |
+|---------|----------|---------|
+| `v0.1`  | Setup initial, intégration du template | `releases/v0.1/` |
+| `v1.0`  | Pages statiques, layout, routing | `releases/v1.0/` |
+| `v1.1`  | Formulaire fonctionnel | `releases/v1.1/` |
+| `v1.2`  | Contenus dynamiques simulés | `releases/v1.2/` |
+| `v2.0`  | Back-office et base de données | `releases/v2.0/` |
+
+---
+
+## 🧰 Technologies utilisées
+
+- Angular v19 + Sass
+- Bootstrap 5 + Font Awesome
+- Alwaysdata (hébergement + base de données)
+- GitHub Issues + Milestones + Kanban
+- Template Stellar Angular Free Admin Template
+
+---
+
+## 🎨 Crédit du template
+
+Ce projet intègre le template **Stellar Angular Free Admin Template**, développé par [BootstrapDash](https://www.bootstrapdash.com/product/stellar-angular-free), distribué sous licence **MIT**.
+
+Source du dépôt : [GitHub – BootstrapDash/stellar-angular-free-admin-template](https://github.com/BootstrapDash/stellar-angular-free-admin-template)
+
+---
+
+## 🗂️ Gestion du dépôt
+
+| Élément | Description |
+|--------|-------------|
+| Branches Git | `main`, `MonLucCo/issueXX` |
+| Labels GitHub | `PLC_setup`, `PLC_typography`, `PLC_frontend`, etc. |
+| Kanban GitHub Project | Organisation agile par colonne et version |
+| Linked Issues | Suivi précis par phase fonctionnelle |
+
+---
+
+## 👨‍💻 Responsable projet
+
+**PERARD (MonLucCo/PerLucCo)** – Chef de projet, développeur, designer  
+📍 itinérant, France
+
+---
+
+## 🤝 Participer au projet
+
+Ce dépôt est actuellement maintenu en solo pour le projet client.  
+Les contributions externes ne sont **pas ouvertes pour le moment**, mais pourront être envisagées dans une version ultérieure.
+
+Si vous souhaitez suggérer une amélioration ou poser une question, vous pouvez créer une `Issue` ou contacter le responsable du projet.
+
+---
+
+## 📄 Licence
+
+Le template technique utilisé pour ce projet est soumis à la licence **MIT**.
+Vous pouvez consulter le texte complet (en français) de la licence dans le fichier [`LICENSE`](LICENSE) situé à la racine du dépôt.
+
+Accès à la version anglaise du texte de la licence [`LICENCE_EN`](./docs/LICENCE_EN.txt).
+
+---
+
+## 📌 Liens utiles
+
+- [Page Facebook Babacar Guide](https://www.facebook.com/babacarguideausenegal)
+- [GitHub Project Kanban](https://github.com/MonLucCo/PLC_Babacar-Tour_web-site/projects)
+- [Cahier des charges – version .docx](docs/CdC-Projet_SiteWeb-Babacar-Tour.docx)

--- a/docs/LICENCE_EN.txt
+++ b/docs/LICENCE_EN.txt
@@ -1,0 +1,22 @@
+MIT License
+Copyright (c) 2025 PERARD (MonLucCo/PerLucCo)
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+🔗 For the original version in English, see [`LICENSE.txt`](../LICENSE.txt)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# 📁 Dossier `docs/` – Documentation du projet
+
+Ce dossier regroupe toutes les ressources liées à la conception du site **Babacar Tour** :
+
+- Cahier des charges
+- Maquettes et schémas de navigation
+- Palette graphique
+- Spécifications techniques ou fonctionnelles
+- Licences et fichiers juridiques
+
+Le contenu de ce dossier n’est pas destiné à la production mais sert à guider le développement et les livraisons.

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,0 +1,11 @@
+# 📦 Dossier `releases/` – Livraisons du projet
+
+Ce dossier regroupe les différentes versions du site livrées au client, organisées par milestones :
+
+- `v0.1` : socle technique et setup initial
+- `v1.0` : structure de navigation et pages statiques
+- `v1.1` : formulaire fonctionnel
+- `v1.2` : contenus dynamiques simulés
+- `v2.0` : back-office et base de données
+
+Chaque version contient des extraits du code, captures, résultats de tests ou notes de validation.

--- a/works/README.md
+++ b/works/README.md
@@ -1,0 +1,10 @@
+# 💻 Dossier `works/` – Développements techniques
+
+Ce dossier contient les sous-projets techniques liés au site **Babacar Tour** :
+
+- `frontend/` : application Angular principale
+- `backend/` : structure serveur ou API REST (optionnel)
+- `assets/` : fichiers partagés (logos, icônes, images brutes)
+- `scratchpad/` : dossier non versionné pour essais hors Git
+
+Chaque sous-dossier dispose de son propre README spécifique. Les livrables sont extraits vers le dossier `releases/` après validation.

--- a/works/assets/.keep
+++ b/works/assets/.keep
@@ -1,0 +1,1 @@
+# Ce fichier permet à Git de versionner ce dossier vide.

--- a/works/backend/.keep
+++ b/works/backend/.keep
@@ -1,0 +1,1 @@
+# Ce fichier permet à Git de versionner ce dossier vide.

--- a/works/frontend/.keep
+++ b/works/frontend/.keep
@@ -1,0 +1,1 @@
+# Ce fichier permet à Git de versionner ce dossier vide.


### PR DESCRIPTION
Fixes #1

---
feat(setup): clôture de l'issue #1 – Initialisation du dépôt et du projet Angular

- Création des dossiers docs/, works/, releases/ + sous-dossiers avec .keep + README internes
- Ajout du fichier LICENCE.txt (MIT – version FR) et lien vers LICENSE_EN
- Configuration du .gitignore (scratchpad/ exclu)
- Rédaction du README.md chapeau structurant le dépôt
- Alignement avec la milestone v0.1

---

# 🛠️ Clôture de l’issue #1 – Initialisation du dépôt Babacar Tour

Cette PR intègre les éléments essentiels du setup du projet :

- Structure du dépôt (`docs/`, `works/`, `releases/`)
- README principal avec table des matières et liens navigables
- Configuration du `.gitignore` + exclusion du dossier scratchpad
- LICENCE MIT version FR + source du template
- Alignement avec la milestone `v0.1 – Site vitrine - fonctionnalité minimale`

✅ L’issue #1 peut être considérée comme **close proprement**  
🔜 Prochaine étape : segmentation des sous-issues liées à `v1.0`  
👨‍💻 Auteur : PERARD / MonLucCo / PerLucCo
